### PR TITLE
Add JustLaunched to Tier 3: AI & SaaS Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Launching on just one platform limits your growth.
 | TopAI.tools | https://topai.tools | SEO-focused AI tools directory |
 | AIStage | https://aistage.net | AI product listing platform |
 | Dang.ai | https://dang.ai | A directory focusing on AI products and startups |
+| JustLaunched | https://justlaunched.fyi | Directory to submit and discover newly launched SaaS products |
 
 ---
 


### PR DESCRIPTION
Hi! I'm the founder of [JustLaunched](https://justlaunched.fyi), a directory where founders submit and discover newly launched SaaS products, organized by category.

Added a single row to the **Tier 3: AI & SaaS Platforms** table, matching the `| Platform | Link | Description |` format. Happy to adjust. Thanks!