### PR TITLE
Add SaaSCity to Tier 5: Startup Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Launching on just one platform limits your growth.
 | Makerhunt | https://makerhunt.io | Launch and showcase maker projects |
 | Sidehunt | https://sidehunt.io | Platform for sharing and exploring side projects |
 | LaunchIgniter | https://launchigniter.com | Platform for startup exposure |
+| SaaSCity | https://saascity.io | Gamified SaaS directory on an isometric city map |
 
 ---
 


### PR DESCRIPTION
Adds **SaaSCity** to the list.

- **URL:** https://saascity.io
- **Submit page:** https://saascity.io/submit
- **Domain Rating:** 46 (Ahrefs)
- **Listing:** free listing with an indexed product page; paid tiers add a dofollow backlink and map placement
- **Review:** every submission is manually reviewed, usually approved within 24h

SaaSCity is a gamified SaaS directory — each listing becomes a building on a live isometric city map.

The entry follows the format already used in this section.