### PR TITLE
Add AISOTools to Tier 3: AI & SaaS Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Launching on just one platform limits your growth.
 | AIStage | https://aistage.net | AI product listing platform |
 | Dang.ai | https://dang.ai | A directory focusing on AI products and startups |
 | JustLaunched | https://justlaunched.fyi | Directory to submit and discover newly launched SaaS products |
+| AISOTools | https://aisotools.com | AI tools directory with free listings plus AI-search visibility monitoring |
 
 ---
 


### PR DESCRIPTION
Adds **AISOTools** (https://aisotools.com) to the Tier 3 table, beside There's An AI For That / Toolify / TopAI.tools.

It is an AI-tools directory that founders can submit to (https://aisotools.com/submit) for a permanent dofollow listing, and it also reports whether ChatGPT, Perplexity and Google AI Overviews actually mention a tool when asked for recommendations in its category — the AI-search equivalent of a rank check.

Listing is free; a $39 one-time option exists purely to skip the review queue and is not required. Flagging that up front so the entry isn't read as a paid-only directory.

Disclosure: I maintain AISOTools. One row appended to the existing Tier 3 table, nothing else touched.