### PR TITLE
Add Phyco to Tier 5: Startup Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Launching on just one platform limits your growth.
 | LaunchIgniter | https://launchigniter.com | Platform for startup exposure |
 | SaaSCity | https://saascity.io | Gamified SaaS directory on an isometric city map |
 | AIWget | https://aiwget.com | Curated directory for AI agents, automation tools, and developer software |
+| Phyco | https://phyco.org | Website catalogue with verified user reviews across 16 categories |
 
 ---
 


### PR DESCRIPTION
Adding [Phyco](https://phyco.org) - a website catalogue with verified user reviews across 16 categories (AI, finance, design, utilities and more). Listings are free, no account required, and every submission is reviewed by hand: https://phyco.org/submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aTConZcDTh57KMn39s5Xd