### PR TITLE
Add Vantaige to Tier 3: AI & SaaS Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Launching on just one platform limits your growth.
 | Dang.ai | https://dang.ai | A directory focusing on AI products and startups |
 | JustLaunched | https://justlaunched.fyi | Directory to submit and discover newly launched SaaS products |
 | AISOTools | https://aisotools.com | AI tools directory with free listings plus AI-search visibility monitoring |
+| Vantaige | https://vantaige.io | Curated AI tools directory and editorial media platform |
 
 ---
 


### PR DESCRIPTION
### Platform Information
- **Platform Name:** Vantaige
- **Link:** https://vantaige.io
- **Category:** Tier 3: AI & SaaS Platforms
- **Description:** Curated AI tools directory and editorial media platform